### PR TITLE
Fix foreground color of One Dark for iTerm

### DIFF
--- a/scheme/iterm/One Dark.itermcolors
+++ b/scheme/iterm/One Dark.itermcolors
@@ -293,13 +293,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.43921568989753723</real>
+		<real>0.74901962280273438</real>
 		<key>Color Space</key>
 		<string>Calibrated</string>
 		<key>Green Component</key>
-		<real>0.38823530077934265</real>
+		<real>0.69803923368453979</real>
 		<key>Red Component</key>
-		<real>0.36078432202339172</real>
+		<real>0.67058825492858887</real>
 	</dict>
 	<key>Link Color</key>
 	<dict>


### PR DESCRIPTION
iTerm's foreground color is too dark and different from Terminal.app's one. This PR fixes it!

Before:
![image](https://user-images.githubusercontent.com/400558/34722216-48238e2a-f589-11e7-85b8-c2462f1ba38b.png)

After:
![image](https://user-images.githubusercontent.com/400558/34722435-42eeb71c-f58a-11e7-94b9-3244166d48b2.png)