### PR TITLE
Set macOS Terminal Type to xterm-256color (the default since OS X 10.7)

### DIFF
--- a/scheme/terminal/One Dark.terminal
+++ b/scheme/terminal/One Dark.terminal
@@ -209,7 +209,7 @@
 	<key>ShowWindowSettingsNameInTitle</key>
 	<true/>
 	<key>TerminalType</key>
-	<string>ansi</string>
+	<string>xterm-256color</string>
 	<key>TextBoldColor</key>
 	<data>
 	YnBsaXN0MDDUAQIDBAUGFRZYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3AS

--- a/scheme/terminal/One Light.terminal
+++ b/scheme/terminal/One Light.terminal
@@ -275,7 +275,7 @@
 	<key>ShowWindowSettingsNameInTitle</key>
 	<true/>
 	<key>TerminalType</key>
-	<string>ansi</string>
+	<string>xterm-256color</string>
 	<key>TextBoldColor</key>
 	<data>
 	YnBsaXN0MDDUAQIDBAUGFRZYJHZlcnNpb25YJG9iamVjdHNZJGFyY2hpdmVyVCR0b3AS


### PR DESCRIPTION
I began using the theme and noticed some applications (`vi` specifically) not functioning how I was used to.

After some digging the reasoning was this theme was setting the terminal type to `ansi`. However, since Mac OS X 10.7 Lion the default terminal has been `xterm-256color` so I think it's best we stick with the default Terminal Type to avoid confusion among users when certain apps `vi`, `screen`,`tmux` etc. start acting differently after they start using this theme.